### PR TITLE
Claude Ghostty MCP server baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,0 +1,223 @@
+# Ghostty MCP Server
+
+A Model Context Protocol (MCP) server that enables AI assistants to interact with [Ghostty](https://ghostty.org/) terminal emulator. This allows AI models to create sessions, send commands, and read terminal output programmatically.
+
+## Features
+
+- **List Sessions**: View all active Ghostty tabs and windows
+- **Create Sessions**: Open new tabs or windows, optionally with a command
+- **Send Keys**: Send text and commands to specific sessions
+- **Read Output**: Read terminal output with chunking support for large outputs
+
+## Platform Support
+
+Currently supports **macOS only** using AppleScript to control Ghostty.
+
+> **Note**: Linux support could be added in the future using D-Bus when Ghostty implements a D-Bus interface. See [Ghostty Discussion #2353](https://github.com/ghostty-org/ghostty/discussions/2353) for API development progress.
+
+## Installation
+
+### Prerequisites
+
+- Node.js >= 18
+- Ghostty terminal emulator installed on macOS
+- macOS with AppleScript support
+
+### Install via npm
+
+```bash
+npm install -g ghostty-mcp
+```
+
+### Build from source
+
+```bash
+git clone <repository-url>
+cd ghostty-mcp
+npm install
+npm run build
+```
+
+## Usage with Claude Desktop
+
+Add to your Claude Desktop configuration file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "ghostty": {
+      "command": "npx",
+      "args": ["-y", "ghostty-mcp"]
+    }
+  }
+}
+```
+
+Or if installed globally:
+
+```json
+{
+  "mcpServers": {
+    "ghostty": {
+      "command": "ghostty-mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+### 1. list_sessions
+
+Lists all active Ghostty sessions (tabs and windows).
+
+**Parameters**: None
+
+**Returns**:
+```json
+[
+  {
+    "id": "window-1-tab-1",
+    "name": "Terminal",
+    "index": 1
+  }
+]
+```
+
+### 2. create_session
+
+Creates a new Ghostty session.
+
+**Parameters**:
+- `type` (optional): `"tab"` or `"window"` (default: `"tab"`)
+- `command` (optional): Command to execute in the new session
+
+**Example**:
+```json
+{
+  "type": "tab",
+  "command": "cd ~/projects && ls -la"
+}
+```
+
+**Returns**:
+```json
+{
+  "success": true,
+  "session": {
+    "id": "window-1-tab-2",
+    "name": "New Tab",
+    "index": 2
+  },
+  "message": "Created new tab: New Tab"
+}
+```
+
+### 3. send_keys
+
+Sends text or commands to a specific session.
+
+**Parameters**:
+- `text` (required): Text to send to the session
+- `session_id` (optional): Target session ID (uses active session if not provided)
+- `press_enter` (optional): Whether to press Enter after sending text (default: `false`)
+
+**Example**:
+```json
+{
+  "session_id": "window-1-tab-1",
+  "text": "echo 'Hello, World!'",
+  "press_enter": true
+}
+```
+
+**Returns**:
+```json
+{
+  "success": true,
+  "message": "Sent text to session window-1-tab-1"
+}
+```
+
+### 4. read_from_session
+
+Reads output from a Ghostty session with chunking support.
+
+**Parameters**:
+- `session_id` (optional): Target session ID (uses active session if not provided)
+- `lines` (optional): Number of lines to read (default: `100`)
+- `offset` (optional): Number of lines to skip from the end for pagination (default: `0`)
+
+**Example**:
+```json
+{
+  "session_id": "window-1-tab-1",
+  "lines": 50,
+  "offset": 0
+}
+```
+
+**Returns**:
+```json
+{
+  "session_id": "window-1-tab-1",
+  "lines": ["line1", "line2", "..."],
+  "total_lines": 150,
+  "lines_returned": 50,
+  "offset": 0
+}
+```
+
+## Development
+
+### Build
+
+```bash
+npm run build
+```
+
+### Watch mode
+
+```bash
+npm run watch
+```
+
+### Debugging
+
+Use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) for debugging:
+
+```bash
+npx @modelcontextprotocol/inspector node dist/index.js
+```
+
+## Limitations
+
+1. **macOS Only**: Currently only supports macOS via AppleScript
+2. **Ghostty AppleScript Support**: Requires Ghostty to support AppleScript commands
+3. **Session IDs**: Session IDs are based on window/tab indices and may change if tabs are closed/reordered
+
+## Future Enhancements
+
+- [ ] Linux support via D-Bus (when Ghostty implements it)
+- [ ] Windows support (when Ghostty provides a control API)
+- [ ] Persistent session IDs
+- [ ] Support for split panes
+- [ ] Terminal output streaming
+- [ ] Better error handling for edge cases
+
+## References
+
+- [Ghostty Documentation](https://ghostty.org/docs)
+- [Ghostty Scripting API Discussion](https://github.com/ghostty-org/ghostty/discussions/2353)
+- [MCP Discussion for Ghostty](https://github.com/ghostty-org/ghostty/discussions/6683)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+
+## License
+
+MIT
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "ghostty-mcp",
+  "version": "1.0.0",
+  "description": "Model Context Protocol server for Ghostty terminal emulator",
+  "main": "dist/index.js",
+  "bin": {
+    "ghostty-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "prepare": "npm run build"
+  },
+  "keywords": [
+    "mcp",
+    "ghostty",
+    "terminal",
+    "model-context-protocol"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src/ghostty.ts
+++ b/src/ghostty.ts
@@ -1,0 +1,238 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface GhosttySession {
+  id: string;
+  name: string;
+  index: number;
+}
+
+export interface SessionOutput {
+  lines: string[];
+  totalLines: number;
+}
+
+/**
+ * Ghostty interaction layer
+ * Uses AppleScript on macOS to control Ghostty terminal
+ */
+export class GhosttyController {
+  /**
+   * Check if running on macOS
+   */
+  private isMacOS(): boolean {
+    return process.platform === 'darwin';
+  }
+
+  /**
+   * Execute AppleScript command
+   */
+  private async runAppleScript(script: string): Promise<string> {
+    if (!this.isMacOS()) {
+      throw new Error('AppleScript is only supported on macOS');
+    }
+
+    try {
+      const { stdout } = await execAsync(`osascript -e '${script.replace(/'/g, "\\'")}'`);
+      return stdout.trim();
+    } catch (error: any) {
+      throw new Error(`AppleScript execution failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * List all Ghostty sessions (tabs/windows)
+   */
+  async listSessions(): Promise<GhosttySession[]> {
+    const script = `
+      tell application "Ghostty"
+        set sessionList to {}
+        set windowCount to count of windows
+
+        repeat with w from 1 to windowCount
+          set tabCount to count of tabs of window w
+          repeat with t from 1 to tabCount
+            set tabName to name of tab t of window w
+            set sessionId to "window-" & w & "-tab-" & t
+            set end of sessionList to {sessionId:sessionId, tabName:tabName, tabIndex:t, windowIndex:w}
+          end repeat
+        end repeat
+
+        set output to ""
+        repeat with s in sessionList
+          set output to output & sessionId of s & "|" & tabName of s & "|" & tabIndex of s & linefeed
+        end repeat
+
+        return output
+      end tell
+    `;
+
+    try {
+      const result = await this.runAppleScript(script);
+
+      if (!result) {
+        return [];
+      }
+
+      const sessions: GhosttySession[] = [];
+      const lines = result.split('\n').filter(line => line.trim());
+
+      for (const line of lines) {
+        const [id, name, indexStr] = line.split('|');
+        if (id && name !== undefined && indexStr) {
+          sessions.push({
+            id: id.trim(),
+            name: name.trim(),
+            index: parseInt(indexStr.trim(), 10)
+          });
+        }
+      }
+
+      return sessions;
+    } catch (error: any) {
+      // If Ghostty is not running or doesn't support AppleScript, return empty array
+      console.error('Error listing sessions:', error.message);
+      return [];
+    }
+  }
+
+  /**
+   * Create a new session (tab or window)
+   */
+  async createSession(type: 'tab' | 'window' = 'tab', command?: string): Promise<GhosttySession> {
+    let script: string;
+
+    if (type === 'window') {
+      script = `
+        tell application "Ghostty"
+          set newWindow to make new window
+          ${command ? `do script "${command.replace(/"/g, '\\"')}" in newWindow` : ''}
+          set windowIndex to index of newWindow
+          return "window-" & windowIndex & "-tab-1|New Window|1"
+        end tell
+      `;
+    } else {
+      script = `
+        tell application "Ghostty"
+          tell front window
+            set newTab to make new tab
+            ${command ? `do script "${command.replace(/"/g, '\\"')}" in newTab` : ''}
+            set tabIndex to index of newTab
+            set windowIndex to index of front window
+            return "window-" & windowIndex & "-tab-" & tabIndex & "|New Tab|" & tabIndex
+          end tell
+        end tell
+      `;
+    }
+
+    const result = await this.runAppleScript(script);
+    const [id, name, indexStr] = result.split('|');
+
+    return {
+      id: id.trim(),
+      name: name.trim(),
+      index: parseInt(indexStr.trim(), 10)
+    };
+  }
+
+  /**
+   * Send keys/text to a specific session
+   */
+  async sendKeys(sessionId: string, text: string, pressEnter: boolean = false): Promise<void> {
+    const [, windowIdx, , tabIdx] = sessionId.split('-');
+
+    const script = `
+      tell application "Ghostty"
+        tell window ${windowIdx}
+          tell tab ${tabIdx}
+            do script "${text.replace(/"/g, '\\"')}${pressEnter ? '\\n' : ''}" in it
+          end tell
+        end tell
+      end tell
+    `;
+
+    await this.runAppleScript(script);
+  }
+
+  /**
+   * Read output from a session with chunking support
+   */
+  async readFromSession(
+    sessionId: string,
+    lines: number = 100,
+    offset: number = 0
+  ): Promise<SessionOutput> {
+    const [, windowIdx, , tabIdx] = sessionId.split('-');
+
+    const script = `
+      tell application "Ghostty"
+        tell window ${windowIdx}
+          tell tab ${tabIdx}
+            set textContent to text of it
+            return textContent
+          end tell
+        end tell
+      end tell
+    `;
+
+    try {
+      const result = await this.runAppleScript(script);
+      const allLines = result.split('\n');
+      const totalLines = allLines.length;
+
+      // Apply offset and limit
+      const startIdx = Math.max(0, totalLines - offset - lines);
+      const endIdx = Math.max(0, totalLines - offset);
+      const selectedLines = allLines.slice(startIdx, endIdx);
+
+      return {
+        lines: selectedLines,
+        totalLines
+      };
+    } catch (error: any) {
+      throw new Error(`Failed to read from session: ${error.message}`);
+    }
+  }
+
+  /**
+   * Get the current active session
+   */
+  async getActiveSession(): Promise<GhosttySession | null> {
+    const script = `
+      tell application "Ghostty"
+        if (count of windows) > 0 then
+          tell front window
+            set windowIdx to index of it
+            if (count of tabs) > 0 then
+              set currentTab to current tab
+              set tabIdx to index of currentTab
+              set tabName to name of currentTab
+              return "window-" & windowIdx & "-tab-" & tabIdx & "|" & tabName & "|" & tabIdx
+            end if
+          end tell
+        end if
+        return ""
+      end tell
+    `;
+
+    try {
+      const result = await this.runAppleScript(script);
+
+      if (!result) {
+        return null;
+      }
+
+      const [id, name, indexStr] = result.split('|');
+
+      return {
+        id: id.trim(),
+        name: name.trim(),
+        index: parseInt(indexStr.trim(), 10)
+      };
+    } catch (error) {
+      return null;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+import { GhosttyController } from './ghostty.js';
+
+/**
+ * Ghostty MCP Server
+ * Provides tools for interacting with Ghostty terminal emulator
+ */
+class GhosttyMCPServer {
+  private server: Server;
+  private ghostty: GhosttyController;
+
+  constructor() {
+    this.ghostty = new GhosttyController();
+    this.server = new Server(
+      {
+        name: 'ghostty-mcp',
+        version: '1.0.0',
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      }
+    );
+
+    this.setupHandlers();
+  }
+
+  private setupHandlers(): void {
+    // List available tools
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+      const tools: Tool[] = [
+        {
+          name: 'list_sessions',
+          description: 'List all active Ghostty sessions (tabs and windows)',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+          },
+        },
+        {
+          name: 'create_session',
+          description: 'Create a new Ghostty session (tab or window)',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              type: {
+                type: 'string',
+                enum: ['tab', 'window'],
+                description: 'Type of session to create (tab or window)',
+                default: 'tab',
+              },
+              command: {
+                type: 'string',
+                description: 'Optional command to execute in the new session',
+              },
+            },
+          },
+        },
+        {
+          name: 'send_keys',
+          description: 'Send text/keys to a specific Ghostty session',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              session_id: {
+                type: 'string',
+                description: 'ID of the target session (from list_sessions)',
+              },
+              text: {
+                type: 'string',
+                description: 'Text to send to the session',
+              },
+              press_enter: {
+                type: 'boolean',
+                description: 'Whether to press Enter after sending the text',
+                default: false,
+              },
+            },
+            required: ['text'],
+          },
+        },
+        {
+          name: 'read_from_session',
+          description: 'Read output from a Ghostty session with chunking support',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              session_id: {
+                type: 'string',
+                description: 'ID of the target session (from list_sessions). If not provided, reads from active session.',
+              },
+              lines: {
+                type: 'number',
+                description: 'Number of lines to read (default: 100)',
+                default: 100,
+              },
+              offset: {
+                type: 'number',
+                description: 'Number of lines to skip from the end (for pagination, default: 0)',
+                default: 0,
+              },
+            },
+          },
+        },
+      ];
+
+      return { tools };
+    });
+
+    // Handle tool calls
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+
+      try {
+        switch (name) {
+          case 'list_sessions': {
+            const sessions = await this.ghostty.listSessions();
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(sessions, null, 2),
+                },
+              ],
+            };
+          }
+
+          case 'create_session': {
+            const type = (args?.type as 'tab' | 'window') || 'tab';
+            const command = args?.command as string | undefined;
+            const session = await this.ghostty.createSession(type, command);
+
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(
+                    {
+                      success: true,
+                      session,
+                      message: `Created new ${type}: ${session.name}`,
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          }
+
+          case 'send_keys': {
+            // Get session_id or use active session
+            let sessionId = args?.session_id as string | undefined;
+
+            if (!sessionId) {
+              const activeSession = await this.ghostty.getActiveSession();
+              if (!activeSession) {
+                throw new Error('No active session found. Please specify session_id.');
+              }
+              sessionId = activeSession.id;
+            }
+
+            const text = args?.text as string;
+            const pressEnter = (args?.press_enter as boolean) || false;
+
+            if (!text) {
+              throw new Error('text parameter is required');
+            }
+
+            await this.ghostty.sendKeys(sessionId, text, pressEnter);
+
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(
+                    {
+                      success: true,
+                      message: `Sent text to session ${sessionId}`,
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          }
+
+          case 'read_from_session': {
+            // Get session_id or use active session
+            let sessionId = args?.session_id as string | undefined;
+
+            if (!sessionId) {
+              const activeSession = await this.ghostty.getActiveSession();
+              if (!activeSession) {
+                throw new Error('No active session found. Please specify session_id.');
+              }
+              sessionId = activeSession.id;
+            }
+
+            const lines = (args?.lines as number) || 100;
+            const offset = (args?.offset as number) || 0;
+
+            const output = await this.ghostty.readFromSession(sessionId, lines, offset);
+
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(
+                    {
+                      session_id: sessionId,
+                      lines: output.lines,
+                      total_lines: output.totalLines,
+                      lines_returned: output.lines.length,
+                      offset,
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          }
+
+          default:
+            throw new Error(`Unknown tool: ${name}`);
+        }
+      } catch (error: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: error.message,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+    });
+  }
+
+  async start(): Promise<void> {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error('Ghostty MCP server running on stdio');
+  }
+}
+
+// Start the server
+const server = new GhosttyMCPServer();
+server.start().catch((error) => {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This PR captures the original Claude-implemented Ghostty MCP server as a baseline for comparison.

Features:
- list_sessions
- create_session
- send_keys
- read_from_session (chunked output)

Implementation details:
- Uses AppleScript on macOS to control Ghostty.
- TypeScript MCP server using @modelcontextprotocol/sdk.

This PR is intended to document and preserve the Claude variant alongside the alternative Augment implementation in PR #1.